### PR TITLE
remove role for text input of date-picker (#63)

### DIFF
--- a/lib/components/DateTime/DatePicker.tsx
+++ b/lib/components/DateTime/DatePicker.tsx
@@ -423,7 +423,6 @@ export class DatePicker extends React.Component<DatePickerProps, Partial<DatePic
                         disabled={this.props.disabled}
                         methodRef={this.inputRef}
                         attr={this.props.attr.input}
-                        role='combobox'
                     />
                     <ActionTriggerButton
                         icon='calendar'


### PR DESCRIPTION
In DatePicker, the button that triggers the calendar pop up has attribute aria-expanded. The text input does not trigger the pop up and is not very reasonable to have aria-expanded attribute although the bug says it should be fixed that way. The solution here removes combobox role for text input since the button and the text input are siblings in element level and it make more sense to me not to assign a combobox role for the text input.

Related task item: https://msazure.visualstudio.com/One/_workitems/edit/3858806